### PR TITLE
Unify alignment and margin constraints to fix negative margins.

### DIFF
--- a/Pod/StackLayout/SLStackLayout.h
+++ b/Pod/StackLayout/SLStackLayout.h
@@ -23,10 +23,11 @@ typedef NS_ENUM(NSInteger, SLAlignment) {
 
 #pragma mark Alignment
 /*
- The alignment pulls subviews to the edges of the superview with a certain priority. Use the fill alignment
+ The alignment pulls subviews to be flush with the margin constraints. Use the fill alignment
  to duplicate behavior of UIStackView.
- When you use the center alignment for the major axis of alignment, two hidden subviews are added to either
- side of the subviews to enforce the centering.
+ When centering is used it respects the centeringAlignmentPriority.
+ When you use the center alignment for the major axis of alignment, a hidden subview is added to
+ help with the centering.
  */
 
 // Defaults to SLAlignmentNone, which creates no constraints
@@ -37,11 +38,12 @@ typedef NS_ENUM(NSInteger, SLAlignment) {
 - (instancetype)setHorizontalAlignment:(SLAlignment)alignment;
 @property (nonatomic, readonly) SLAlignment horizontalAlignment;
 
-/* This is the priority that all alignment constraints use. It defaults to UILayoutPriorityDefaultHigh + 10. This
- is so views will pull in the aligned direction, but will not override margin constraints (which are required).
+/* 
+ This is the priority for constraints used for centering views with SLAlignmentCenter. It defaults to
+ UILayoutPriorityDefaultHigh + 10.
  */
-- (instancetype)setAlignmentPriority:(UILayoutPriority)priority;
-@property (nonatomic, readonly) UILayoutPriority alignmentPriority;
+- (instancetype)setCenteringAlignmentPriority:(UILayoutPriority)priority;
+@property (nonatomic, readonly) UILayoutPriority centeringAlignmentPriority;
 
 #pragma mark Spacing
 /*


### PR DESCRIPTION
It turns out negative margins didn't work with StackLayout. The problem was subtle though.

I used to have margin constraints, that the `subview.leading >= superview.leading + margin`. Basically this makes sure the subview never enters the margin, but it doesn't "pull" the subview to the margin.

To do alignment, I'd add other constraints that strongly pull the subviews to one side or another. For example, `subview.leading = superview.leading`. The idea is that this would pull to the leading side but would not be strong enough to override the margins. Then you could change the margins without touching the alignment constraints.

This doesn't work when the margin was negative though. The alignment would pull the subview all the way to the leading side then be satisfied. I'd have to make a constraint that tries to pull the `subview.leading = superview.leading - someLargeNumber`, which seems dirty. It would be really tricky to debug too.

The new approach is much simpler. Usually the margin constraints have a `>=` relation, but if you are using a leading alignment then the constraint will be `==`. I wish I had thought of it before....

ptal @charlesmchen 
